### PR TITLE
update img tagging policy and fix the version file in the image

### DIFF
--- a/.github/workflows/push-img-docker-hub.yaml
+++ b/.github/workflows/push-img-docker-hub.yaml
@@ -23,10 +23,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: lapwingcloud/echoserver
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Write Version to File
-        run: |-
-          echo "${{ steps.meta.outputs.tags }}" > version.txt
+        run: |
+          echo "${{ github.ref_name }}" > version.txt
 
       - name: Build and Push Docker Image to Docker Hub
         uses: docker/build-push-action@v5


### PR DESCRIPTION
previously the job will generate

- latest
- v0.1.0

now the job should generate tags

- latest
- 0.1
- 0.1.1

also previous the version.txt is `lapwingcloud/echoserver:v0.1.1\nlapwingcloud/echoserver:latest` , now expect to be the tag name, e.g. `v0.1.1`