### PR TITLE
fix dockerfile signal forwarding issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ FROM debian:12
 
 COPY --from=builder /code/echoserver /bin/echoserver
 COPY version.txt version.txt
-CMD echoserver
+CMD ["echoserver"]


### PR DESCRIPTION
when using `CMD echoserver`, docker doesn't forward the signal to the process unless specified with `-it` 

but when using `CMD ["echoserver"]`, it does forward signal without `-it` flags

currently still don't know the detailed reason but likely something to do with the argument form passed to `bash -c` , ref https://hynek.me/articles/docker-signals/